### PR TITLE
Add tags to each step in terminate playbook

### DIFF
--- a/ansible/terminate_workers.yml
+++ b/ansible/terminate_workers.yml
@@ -4,9 +4,13 @@
 - pause: prompt="ctrl-C TO NOT TERMINATE INSTANCES"
 - name: stop rqworker gracefully
   shell: /usr/local/bin/stop-rqworker.sh
+  tags: 
+    - stop-worker
 - name: terminate workers
   local_action:
     module: ec2
     state: absent
     region: "{{ region }}"
     instance_ids: "{{ ec2_id }}"
+  tags:
+    - terminate-instance


### PR DESCRIPTION
Sometimes stop-rqworker fails, but still want to terminate instances