### PR TITLE
Use x.swle7i.ng.0001.usw2.cache.amazonaws.com as redis endpoint

### DIFF
--- a/ansible/group_vars/prod
+++ b/ansible/group_vars/prod
@@ -1,5 +1,5 @@
 ---
-redis_host: x-002.swle7i.0001.usw2.cache.amazonaws.com:6379
+redis_host: x.swle7i.ng.0001.usw2.cache.amazonaws.com
 subnet_id_public: subnet-ee63cf99
 subnet_id_private: subnet-1bbe676c
 sec_grp_ingest_front_id: sg-97b298f2

--- a/ansible/group_vars/stage
+++ b/ansible/group_vars/stage
@@ -1,5 +1,5 @@
 ---
-redis_host: x-002.swle7i.0001.usw2.cache.amazonaws.com:6379
+redis_host: x.swle7i.ng.0001.usw2.cache.amazonaws.com
 subnet_id_public: subnet-b07689e9
 subnet_id_private: subnet-56758a0f
 sec_grp_ingest_front_id: sg-8a28c5ee

--- a/ansible/roles/worker/vars/main-prod.yml
+++ b/ansible/roles/worker/vars/main-prod.yml
@@ -1,6 +1,6 @@
 DATA_BRANCH: production
 
-redis_host: x-002.swle7i.0001.usw2.cache.amazonaws.com
+redis_host: x.swle7i.ng.0001.usw2.cache.amazonaws.com
 redis_port: 6379
 redis_password: "{{ redis_password_prod }}"
 redis_connect_timeout: 10

--- a/ansible/roles/worker/vars/main-stage.yml
+++ b/ansible/roles/worker/vars/main-stage.yml
@@ -1,6 +1,6 @@
 DATA_BRANCH: stage
 
-redis_host: x-002.swle7i.0001.usw2.cache.amazonaws.com
+redis_host: x.swle7i.ng.0001.usw2.cache.amazonaws.com
 redis_port: 6379
 redis_password: "{{ redis_password_stage }}"
 redis_connect_timeout: 10


### PR DESCRIPTION
this is the main one that load balances to the 2 cache clusters
Shouldn't have read only problem.