### PR TITLE
Change how stop-rqworker works, timeout==30s

### DIFF
--- a/ansible/roles/worker/templates/stop-rqworker.sh.j2
+++ b/ansible/roles/worker/templates/stop-rqworker.sh.j2
@@ -17,7 +17,12 @@ if [[ $PID_RQW == $rq_running ]]; then
     kill $PID_RQW
 fi
 
+i=0
 while test -d "/proc/$PID_RQW"; do
+	if [ $i -gt 30 ]; then
+		exit 11
+	fi
   sleep 1
+  let i+=1
 done
 /bin/rm {{ dir_run_rqworker }}/rqworker.pid

--- a/ansible/terminate_workers.yml
+++ b/ansible/terminate_workers.yml
@@ -6,7 +6,6 @@
     - terminate-instances
 - name: stop rqworker gracefully
   shell: /usr/local/bin/stop-rqworker.sh
-  ignore_errors: yes
   tags: 
     - stop-worker
 - name: terminate workers


### PR DESCRIPTION
This way you can run terminate with no	qualifiers and workers running
jobs won't be terminated.