### PR TITLE
Ignore failure to stop rqworker.

### DIFF
--- a/ansible/terminate_workers.yml
+++ b/ansible/terminate_workers.yml
@@ -7,7 +7,8 @@
 - name: stop rqworker gracefully
   shell: /usr/local/bin/stop-rqworker.sh
   tags: 
-    - stop-worker
+    - stop-rqworker
+  ignore_errors: yes
 - name: terminate workers
   local_action:
     module: ec2


### PR DESCRIPTION
This is so un provisioned workers will fail. The "force" option is
default now