### PR TITLE
Add creates so doesn't fail on rerun

### DIFF
--- a/ansible/roles/worker/tasks/install_deep_harvester.yml
+++ b/ansible/roles/worker/tasks/install_deep_harvester.yml
@@ -20,6 +20,8 @@
 - name: install mscorefonts from http://mscorefonts2.sourceforge.net/
   become: yes
   command: rpm -i https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
+  args:
+    creates: /usr/share/fonts/msttcore
 - name: make directory for ffmpeg download
   file:
     state: directory


### PR DESCRIPTION
running rpm -i again fails if package installed, checking /usr/share/fonts/msttcore existence skips this step if they are already there